### PR TITLE
fix for chromosome type issue

### DIFF
--- a/minda/decompose.py
+++ b/minda/decompose.py
@@ -91,6 +91,8 @@ def _get_sorted_df(df):
     Sorts dataframe by #CHROM and POS
     
     """
+    # handles instances where chromosomes are only integers
+    df["#CHROM"] = df["#CHROM"].astype(str)
     chrom_value = df.iloc[0,0]
     if chrom_value.startswith("chr"):
         chrom_set = set(df["#CHROM"].str.slice(start=3).to_list())


### PR DESCRIPTION
Hello,

Thank you for building this wonderful tool! We've incorporated it into several of our workflows and have found it to be invaluable. My colleague, @eliko1991, and I noticed that there is a small bug in the decompose.py script. When the SVs that are in the VCF that minda is attempting to decompose consistents only of SVs that are on chromosomes with integer names, the type of the `df["#CHROM"]` column is an integer, and the if statement on [line 95](https://github.com/KolmogorovLab/minda/blob/47d0fb5484b2b15865a94a9ba81436beaf52cf16/minda/decompose.py#L95) fails. We added in a line above it to ensure that the type is str not int.

Hope this makes sense. Happy to explain further and thanks again for the great tool.

Best wishes,
Asher